### PR TITLE
Add link to related Medium blog post in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Each model has **usage limits**, so don’t expect to run production workloads.
 
 > ✅ For experimenting, comparing models, and learning — it’s a fantastic playground.  
 
+## 📖 Blog Post
+
+Read the full tutorial on Medium:
+
+👉 [Exploring GitHub Models with a .NET Console Chat Application](https://medium.com/medialesson/exploring-github-models-with-a-net-console-chat-application-348890adcb6b)
+
 ## 📚 Resources
 
 - [GitHub Models Documentation](https://docs.github.com/en/github-models)  


### PR DESCRIPTION
This pull request adds a new section to the `README.md` file to provide a link to a related blog post. This makes it easier for users to find a more detailed tutorial on using GitHub models with a .NET console chat application.

Documentation update:

* Added a "Blog Post" section to `README.md` with a link to a Medium tutorial on exploring GitHub models using a .NET console chat application.